### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pymongo==3.11.0
 requests==2.24.0
-python_telegram_bot==12.8
+python_telegram_bot==13.0
 beautifulsoup4==4.9.2
 telegram==0.0.1


### PR DESCRIPTION
It seems there's an issue with python_telegram_bot v12.8 that causes import errors with the telegram package.
Other instances of this issue cropping up are:
https://github.com/python-telegram-bot/python-telegram-bot/issues/395
https://github.com/Tkd-Alex/Telegram-InstaPy-Scheduling/issues/13
https://github.com/python-telegram-bot/python-telegram-bot/issues/1670
https://stackoverflow.com/questions/59446910/importerror-cannot-import-name-type-python-telegram-bot
https://stackoverflow.com/questions/58067952/importerror-cannot-import-name-message-from-exchangelib-folders
https://github.com/python-telegram-bot/python-telegram-bot/issues/1223


The working solution seems to be upgrading to v13.0